### PR TITLE
Fix startup delay issue

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,7 +156,6 @@ class FlaskComfyUIApp:
             
             # Wait for servers to initialize
             print("Waiting for ComfyUI servers to initialize...")
-            time.sleep(10)
             
             # Verify all servers are running
             all_running = True


### PR DESCRIPTION
## Summary
- remove extra sleep during server initialization

## Testing
- `python test_diagnostics.py`
- `python test_features.py`


------
https://chatgpt.com/codex/tasks/task_e_687962f986b08333b1931aefbe3a214b